### PR TITLE
Fix tinytex install error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rocker/tidyverse:4.4.3
 ENV PATH="$PATH:/root/bin:/usr/local/lib"
 
 # Install TinyTeX and necessary LaTeX packages
-RUN Rscript -e 'install.packages("tinytex", repos = "https://cloud.r-project.org")' && \
+RUN Rscript -e 'devtools::install_version("tinytex", version="0.59", repos="https://cloud.r-project.org")' && \
     Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1")' && \
     Rscript -e 'tinytex::tlmgr_install(c( \
       "multirow", "ulem", "environ", "colortbl", "wrapfig", "pdflscape", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ FROM rocker/tidyverse:4.4.3
 ENV PATH="$PATH:/root/bin:/usr/local/lib"
 
 # Install TinyTeX and necessary LaTeX packages
-RUN Rscript -e 'tinytex::install_tinytex(bundle = "TinyTeX-1-linux-x86_64")' && \
+RUN Rscript -e 'install.packages("tinytex", repos = "https://cloud.r-project.org")' && \
+    Rscript -e 'tinytex::install_tinytex(version = "latest", bundle = "TinyTeX-1")' && \
     Rscript -e 'tinytex::tlmgr_install(c( \
       "multirow", "ulem", "environ", "colortbl", "wrapfig", "pdflscape", \
       "tabu", "threeparttable", "threeparttablex", "makecell", "caption", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rocker/tidyverse:4.4.3
 ENV PATH="$PATH:/root/bin:/usr/local/lib"
 
 # Install TinyTeX and necessary LaTeX packages
-RUN Rscript -e 'tinytex::install_tinytex()' && \
+RUN Rscript -e 'tinytex::install_tinytex(bundle = "TinyTeX-1")' && \
     Rscript -e 'tinytex::tlmgr_install(c( \
       "multirow", "ulem", "environ", "colortbl", "wrapfig", "pdflscape", \
       "tabu", "threeparttable", "threeparttablex", "makecell", "caption", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM rocker/tidyverse:4.4.3
 ENV PATH="$PATH:/root/bin:/usr/local/lib"
 
 # Install TinyTeX and necessary LaTeX packages
-RUN Rscript -e 'tinytex::install_tinytex(bundle = "TinyTeX-1")' && \
+RUN Rscript -e 'tinytex::install_tinytex(bundle = "TinyTeX-1-linux-x86_64")' && \
     Rscript -e 'tinytex::tlmgr_install(c( \
       "multirow", "ulem", "environ", "colortbl", "wrapfig", "pdflscape", \
       "tabu", "threeparttable", "threeparttablex", "makecell", "caption", \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="$PATH:/root/bin:/usr/local/lib"
 
 # Install TinyTeX and necessary LaTeX packages
 RUN Rscript -e 'install.packages("tinytex", repos = "https://cloud.r-project.org")' && \
-    Rscript -e 'tinytex::install_tinytex(version = "latest", bundle = "TinyTeX-1")' && \
+    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1")' && \
     Rscript -e 'tinytex::tlmgr_install(c( \
       "multirow", "ulem", "environ", "colortbl", "wrapfig", "pdflscape", \
       "tabu", "threeparttable", "threeparttablex", "makecell", "caption", \


### PR DESCRIPTION
## Issue
Builds began failing with a 404 error when installing TinyTeX using the default installer. This resulted in a failed download attempt at `https://yihui.org/tinytex/TinyTeX-1.tar.gz`

Refer to the failed Cloud build: 
https://console.cloud.google.com/cloud-build/builds;region=global/9d6a129f-b2ba-4901-b7dc-bb6d9f513187?inv=1&invt=Abw2Ag&project=nih-nci-dceg-connect-prod-6d04&supportedpurview=project

Relevant log output:
```
Step 3/30 : RUN Rscript -e 'tinytex::install_tinytex()' &&     Rscript -e 'tinytex::tlmgr_install(c(       "multirow", "ulem", "environ", "colortbl", "wrapfig", "pdflscape",       "tabu", "threeparttable", "threeparttablex", "makecell", "caption",       "anyfontsize"))'
--
  | ---> Running in 6ea4d42f495e
  | trying URL 'https://yihui.org/tinytex/TinyTeX-1.tar.gz'
  | trying URL 'https://yihui.org/tinytex/TinyTeX-1.tar.gz'
  | --2026-04-02 14:37:07--  https://yihui.org/tinytex/TinyTeX-1.tar.gz
  | Resolving yihui.org (yihui.org)... 172.67.140.24, 104.21.87.33, 2606:4700:3032::ac43:8c18, ...
  | Connecting to yihui.org (yihui.org)\|172.67.140.24\|:443... connected.
  | HTTP request sent, awaiting response... 301 Moved Permanently
  | Location: https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1.tar.gz [following]
  | --2026-04-02 14:37:07--  https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1.tar.gz
  | Resolving github.com (github.com)... 140.82.116.3
  | Connecting to github.com (github.com)\|140.82.116.3\|:443... connected.
  | HTTP request sent, awaiting response... 404 Not Found
  | 2026-04-02 14:37:07 ERROR 404: Not Found.
```
## Root Cause
The failure originates from how tinytex::install_tinytex() resolves the TinyTeX download URL:
- The function constructs a URL based on internal logic in the tinytex R package
- Older/default behavior attempts to download from: `https://yihui.org/tinytex/TinyTeX-1.tar.gz`
- This URL now redirects to a non-existent “daily” GitHub release, resulting in a 404
- TinyTeX introduced a new binary naming scheme (e.g., `TinyTeX-1-linux-x86_64.tar.xz`)
- Correct resolution of these filenames depends on updated logic in newer versions of the tinytex package

See TinyTeX/tinytex release notes for v0.59: https://github.com/rstudio/tinytex/releases/tag/v0.59

## Fix
Replace the default installer with a pinned and explicit configuration. This ensures:
- The installer uses updated logic (from tinytex 0.59)
- The correct TinyTeX release (2026.04, TinyTeX-1) is downloaded
- The invalid legacy URL path is avoided

Successful Cloud Build run: https://console.cloud.google.com/cloud-build/builds;region=global/555734a2-d4ba-49ed-934e-7bf4fb2a0066?project=nih-nci-dceg-connect-prod-6d04

## Alternatives Considered
The following configurations also succeeded:

- 771a18f: no version pinning
- 0f51908: pinning only the TinyTeX version (2026.04)

However, these approaches rely on upstream defaults and may break again if installer behavior changes. Pinning both the tinytex package and TinyTeX version provides stronger guarantees of reproducibility and prevents regressions like the previously observed 404 error.