### PR TITLE
Fix non-interactive authentication error in Monthly Data Destruction Report

### DIFF
--- a/Data Destruction CSV Output.R
+++ b/Data Destruction CSV Output.R
@@ -15,7 +15,7 @@ library(glue)
 
 
 
-bq_auth(scopes = "https://www.googleapis.com/auth/bigquery")
+bq_auth()
 
 
 ## Monthly report

--- a/Data Destruction CSV Output.R
+++ b/Data Destruction CSV Output.R
@@ -14,9 +14,16 @@ library(kableExtra)
 library(glue)
 
 
-
+print(packageVersion("bigrquery"))
+print(packageVersion("gargle"))
+print(Sys.getenv("GOOGLE_CLOUD_PROJECT"))  # should show your project ID
+print(Sys.getenv("GOOGLE_APPLICATION_CREDENTIALS"))  # any explicit creds set?
+print(interactive())          # should return FALSE in Cloud Build
+print(Sys.getenv("USER"))     # what user is running the script
+print(Sys.getenv("HOME"))     # home directory being used
+print("Starting BigQuery Authentication")
 bq_auth()
-
+print("BigQuery Authentication Successful")
 
 ## Monthly report
 boxfolder <- 255783409227 # Active Box Folder

--- a/Data Destruction CSV Output.R
+++ b/Data Destruction CSV Output.R
@@ -14,21 +14,12 @@ library(kableExtra)
 library(glue)
 
 
-print(packageVersion("bigrquery"))
-print(packageVersion("gargle"))
-print(Sys.getenv("GOOGLE_CLOUD_PROJECT"))  # should show your project ID
-print(Sys.getenv("GOOGLE_APPLICATION_CREDENTIALS"))  # any explicit creds set?
-print(interactive())          # should return FALSE in Cloud Build
-print(Sys.getenv("USER"))     # what user is running the script
-print(Sys.getenv("HOME"))     # home directory being used
-print("Starting BigQuery Authentication")
-bq_auth()
-print("BigQuery Authentication Successful")
-print(bq_user())
+
+bq_auth(scopes = "https://www.googleapis.com/auth/bigquery")
+
 
 ## Monthly report
 boxfolder <- 255783409227 # Active Box Folder
-print(boxfolder)
 
 currentDate <- Sys.Date()##### Making sure personal C drives aren't referenced if this code is being used by others
 
@@ -43,7 +34,7 @@ write_to_local_drive = F
 local_drive= ifelse(write_to_local_drive, "C:/Users/dowlingk2/Documents/GitHub/", "")
 
 currentDate <- Sys.Date()
-print(currentDate)
+
 
 #################################################################################################################
 
@@ -56,19 +47,11 @@ d_253883960, d_459098666,  d_265193023, d_126331570, d_878865966, d_167958071, d
 FROM `nih-nci-dceg-connect-prod-6d04.FlatConnect.participants` where Connect_ID IS NOT NULL and d_831041022='353358909'"  #d_220186468,
 spec_query <- "SELECT Connect_ID, d_820476880 FROM `nih-nci-dceg-connect-prod-6d04.FlatConnect.biospecimen` where Connect_ID is not null"
 
-print("Running datad query...")
 datad_table_cc <- bq_project_query(project_cc, datad_query)
-print("datad query complete")
-
 datad <- bq_table_download(datad_table_cc, bigint = "integer64")
-print("datad download complete")
 
-print("Running spec query...")
 spec_table_cc <- bq_project_query(project_cc, spec_query)
-print("spec query complete")
-
 spec <- bq_table_download(spec_table_cc, bigint = "integer64")
-print("spec download complete")
 
 spec$Connect_ID <- as.numeric(spec$Connect_ID)
 datad$Connect_ID <- as.numeric(datad$Connect_ID)

--- a/Data Destruction CSV Output.R
+++ b/Data Destruction CSV Output.R
@@ -24,9 +24,11 @@ print(Sys.getenv("HOME"))     # home directory being used
 print("Starting BigQuery Authentication")
 bq_auth()
 print("BigQuery Authentication Successful")
+print(bq_user())
 
 ## Monthly report
 boxfolder <- 255783409227 # Active Box Folder
+print(boxfolder)
 
 currentDate <- Sys.Date()##### Making sure personal C drives aren't referenced if this code is being used by others
 
@@ -41,7 +43,7 @@ write_to_local_drive = F
 local_drive= ifelse(write_to_local_drive, "C:/Users/dowlingk2/Documents/GitHub/", "")
 
 currentDate <- Sys.Date()
-
+print(currentDate)
 
 #################################################################################################################
 
@@ -54,11 +56,19 @@ d_253883960, d_459098666,  d_265193023, d_126331570, d_878865966, d_167958071, d
 FROM `nih-nci-dceg-connect-prod-6d04.FlatConnect.participants` where Connect_ID IS NOT NULL and d_831041022='353358909'"  #d_220186468,
 spec_query <- "SELECT Connect_ID, d_820476880 FROM `nih-nci-dceg-connect-prod-6d04.FlatConnect.biospecimen` where Connect_ID is not null"
 
+print("Running datad query...")
 datad_table_cc <- bq_project_query(project_cc, datad_query)
-datad <- bq_table_download(datad_table_cc, bigint = "integer64")
+print("datad query complete")
 
+datad <- bq_table_download(datad_table_cc, bigint = "integer64")
+print("datad download complete")
+
+print("Running spec query...")
 spec_table_cc <- bq_project_query(project_cc, spec_query)
+print("spec query complete")
+
 spec <- bq_table_download(spec_table_cc, bigint = "integer64")
+print("spec download complete")
 
 spec$Connect_ID <- as.numeric(spec$Connect_ID)
 datad$Connect_ID <- as.numeric(datad$Connect_ID)

--- a/ccc_module_metrics_api.R
+++ b/ccc_module_metrics_api.R
@@ -78,12 +78,7 @@ function(report, testing = FALSE) {
     if (is.null(output_format)) {
       stop("Report file extension is invalid. Script did not execute.")
     }
-    
-    # Authenticate with Google Storage and write report file to bucket
-    #scope <- c("https://www.googleapis.com/auth/cloud-platform")
-    #token <- token_fetch(scopes = scope)
-    #gcs_auth(token = token)
-    
+
     tryCatch({
       # Render the rmarkdown file
       rmarkdown::render(r_file_name,
@@ -104,9 +99,6 @@ function(report, testing = FALSE) {
       })
     })
   } else if (is_r_file) {
-      #scope <- c("https://www.googleapis.com/auth/cloud-platform")
-      #token <- token_fetch(scopes = scope)
-      #gcs_auth(token = token)
       source(r_file_name)
   } else {
     stop("The file extension of the R script is invalid. Script did not execute.") 

--- a/ccc_module_metrics_api.R
+++ b/ccc_module_metrics_api.R
@@ -99,7 +99,10 @@ function(report, testing = FALSE) {
       })
     })
   } else if (is_r_file) {
-    source(r_file_name)
+      scope <- c("https://www.googleapis.com/auth/cloud-platform")
+      token <- token_fetch(scopes = scope)
+      gcs_auth(token = token)
+      source(r_file_name)
   } else {
     stop("The file extension of the R script is invalid. Script did not execute.") 
   }

--- a/ccc_module_metrics_api.R
+++ b/ccc_module_metrics_api.R
@@ -56,6 +56,11 @@ function(report, testing = FALSE) {
   is_rmd_file <- grepl("\\.rmd$", r_file_name
                      , ignore.case = TRUE) # TRUE if ends in ".rmd"
 
+  # Authenticate with Google Storage
+  scope <- c("https://www.googleapis.com/auth/cloud-platform")
+  token <- token_fetch(scopes = scope)
+  gcs_auth(token = token)
+
   if (is_rmd_file) {
     # Add time stamp and box folder tag to to report name
     report_fid <- paste0(
@@ -75,9 +80,9 @@ function(report, testing = FALSE) {
     }
     
     # Authenticate with Google Storage and write report file to bucket
-    scope <- c("https://www.googleapis.com/auth/cloud-platform")
-    token <- token_fetch(scopes = scope)
-    gcs_auth(token = token)
+    #scope <- c("https://www.googleapis.com/auth/cloud-platform")
+    #token <- token_fetch(scopes = scope)
+    #gcs_auth(token = token)
     
     tryCatch({
       # Render the rmarkdown file
@@ -99,9 +104,9 @@ function(report, testing = FALSE) {
       })
     })
   } else if (is_r_file) {
-      scope <- c("https://www.googleapis.com/auth/cloud-platform")
-      token <- token_fetch(scopes = scope)
-      gcs_auth(token = token)
+      #scope <- c("https://www.googleapis.com/auth/cloud-platform")
+      #token <- token_fetch(scopes = scope)
+      #gcs_auth(token = token)
       source(r_file_name)
   } else {
     stop("The file extension of the R script is invalid. Script did not execute.") 

--- a/ccc_module_metrics_api.R
+++ b/ccc_module_metrics_api.R
@@ -99,7 +99,7 @@ function(report, testing = FALSE) {
       })
     })
   } else if (is_r_file) {
-      source(r_file_name)
+    source(r_file_name)
   } else {
     stop("The file extension of the R script is invalid. Script did not execute.") 
   }


### PR DESCRIPTION
**Issue**
The Monthly Data Destruction Report was failing with the following error:
```
<simpleError in value[[3L]](cond): Non-interactive session and no authentication email selected.

Setup JSON service email auth or specify email in gar_auth(email='me@preauthenticated.com')>
```

**Root Cause**
In `ccc_module_metrics_api.R`, the Google Cloud Storage authentication (token_fetch/gcs_auth) was scoped inside the `is_rmd_file` branch of the if/else block. Since the Data Destruction report is an `.R` file and not an `.Rmd`, it went through the `is_r_file` branch instead, which never authenticated with GCS. When the script then attempted to upload the output CSV to GCS, it failed due to missing credentials.

This was not an issue for any RMD-based reports since they always passed through the authenticated branch.

**Fix**
Moved the GCS authentication block above the if/else statement, so it runs once for both `.R` and `.Rmd` file paths, removing the redundant and incomplete per-branch authentication.