### PR TITLE
Pin TinyTeX to Princeton CTAN mirror to avoid fallback issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="$PATH:/root/bin:/usr/local/lib"
 
 # Install TinyTeX and necessary LaTeX packages
 RUN Rscript -e 'devtools::install_version("tinytex", version="0.59", repos="https://cloud.r-project.org")' && \
-    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1")' && \
+    Rscript -e 'tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1", repository = "https://mirror.math.princeton.edu/pub/CTAN")' && \
     Rscript -e 'tinytex::tlmgr_install(c( \
       "multirow", "ulem", "environ", "colortbl", "wrapfig", "pdflscape", \
       "tabu", "threeparttable", "threeparttablex", "makecell", "caption", \


### PR DESCRIPTION
**Issue**
The pipeline intermittently fails during the R Markdown → Pandoc → XeLaTeX process due to TinyTeX repository and mirror inconsistencies.

The configured TinyTeX repository (https://tlnet.yihui.org) becomes inaccessible or returns invalid responses, which causes TinyTeX to fall back to the default CTAN mirror network (https://mirror.ctan.org). This network dynamically selects mirrors per request, resulting in non-deterministic behavior across runs.

For example:
- On 5/4/2026 (~10:30 AM), a run failed with:
`Remote database ... seems to be older than the local installation` using `ctan.math.illinois.edu`
- A subsequent forced run on 5/4/2026 (~5 PM) succeeded using a different mirror (`mirrors.rit.edu`)

This demonstrates that pipeline success depends on which CTAN mirror is selected at runtime.

A similar issue and solution were previously addressed in ccc_biospecimen_metrics_gcp_pipeline ([#221](https://github.com/Analyticsphere/ccc_biospecimen_metrics_gcp_pipeline/pull/221)).

Cloud Build log on 5/1/2026
https://console.cloud.google.com/cloud-build/builds;region=global/81beeda4-b880-49cb-8295-170f6e1bf118?project=nih-nci-dceg-connect-prod-6d04
```
tlmgr option sys_bin ~/bin
tlmgr: setting option sys_bin to /root/bin.
tlmgr: updating /root/.TinyTeX/tlpkg/texlive.tlpdb
tlmgr option repository 'https://tlnet.yihui.org/systems/texlive/tlnet'
tlmgr: setting default package repository to https://tlnet.yihui.org/systems/texlive/tlnet
tlmgr: updating /root/.TinyTeX/tlpkg/texlive.tlpdb
tlmgr update --list
First directive needs to be 'name', not <!DOCTYPE html> at /root/.TinyTeX/tlpkg/TeXLive/TLPOBJ.pm line 106, <$retfh> line 1.
tlmgr option repository ctan
tlmgr: setting default package repository to https://mirror.ctan.org/systems/texlive/tlnet
tlmgr: updating /root/.TinyTeX/tlpkg/texlive.tlpdb
You may have to restart your system after installing TinyTeX to make sure ~/bin appears in your PATH variable (https://github.com/rstudio/tinytex/issues/16).
Warning message:
In tinytex::install_tinytex(version = "2026.04", bundle = "TinyTeX-1") :
  The repository https://tlnet.yihui.org does not seem to be accessible. Reverting to the default CTAN mirror.
tlmgr install multirow ulem environ colortbl wrapfig pdflscape tabu threeparttable threeparttablex makecell caption anyfontsize
tlmgr: package repository https://ctan.math.washington.edu/tex-archive/systems/texlive/tlnet (not verified: gpg unavailable)
[1/14, ??:??/??:??] install: anyfontsize [3k]
[2/14, 00:01/01:02] install: caption [61k]
[3/14, 00:01/00:02] install: colortbl [4k]
[4/14, 00:01/00:01] install: environ [2k]
[5/14, 00:01/00:01] install: makecell [5k]
[6/14, 00:01/00:01] install: multirow [3k]
[7/14, 00:01/00:01] install: pdflscape [3k]
[8/14, 00:01/00:01] install: tabu [24k]
[9/14, 00:01/00:01] install: threeparttable [6k]
[10/14, 00:01/00:01] install: threeparttablex [3k]
[11/14, 00:02/00:02] install: trimspaces [1k]
[12/14, 00:02/00:02] install: ulem [7k]
[13/14, 00:02/00:02] install: varwidth [5k]
[14/14, 00:02/00:02] install: wrapfig [10k]
```

Cloud Run on 5/4/2026 at ~10:30 AM that failed (automated run)
```
026-05-04 10:43:34.977 EDT /usr/bin/pandoc +RTS -K512m -RTS CCC-Weekly-Module-Metrics_RMD.knit.md --to latex --from markdown+autolink_bare_uris+tex_math_single_backslash --output CCC_Weekly_Module_Metrics_05_04_2026_boxfolder_251929835507.tex --lua-filter /usr/local/lib/R/site-library/rmarkdown/rmarkdown/lua/pagebreak.lua --lua-filter /usr/local/lib/R/site-library/rmarkdown/rmarkdown/lua/latex-div.lua --embed-resources --standalone --table-of-contents --toc-depth 2 --highlight-style tango --pdf-engine xelatex --variable graphics --include-in-header /tmp/RtmpMe7htM/rmarkdown-str143a42fd2.html --variable 'geometry:margin=1in' --include-in-header /tmp/RtmpMe7htM/rmarkdown-str153162742.html
2026-05-04 10:43:35.028 EDT [WARNING] Deprecated: --highlight-style. Use --syntax-highlighting instead.
2026-05-04 10:44:19.257 EDT tlmgr: Remote database at https://ctan.math.illinois.edu/systems/texlive/tlnet
2026-05-04 10:44:19.257 EDT (revision 78878 of the texlive-scripts package)
2026-05-04 10:44:19.257 EDT seems to be older than the local installation
2026-05-04 10:44:19.257 EDT (revision 78893 of texlive-scripts);
2026-05-04 10:44:19.257 EDT please use a different mirror and/or wait a day or two.
2026-05-04 10:44:19.316 EDT ! LaTeX Error: File `placeins.sty' not found.
2026-05-04 10:44:19.316 EDT ! Emergency stop.
2026-05-04 10:44:19.316 EDT <read *>
2026-05-04 10:44:19.318 EDT [1] "Rendering failed with error:  LaTeX failed to compile CCC_Weekly_Module_Metrics_05_04_2026_boxfolder_251929835507.tex. See https://yihui.org/tinytex/r/#debugging for debugging tips. See CCC_Weekly_Module_Metrics_05_04_2026_boxfolder_251929835507.log for more info."
```

Cloud Run on 5/5/2026 at ~5 PM that passed (forced run)
```
2026-05-04 17:06:20.639 EDT /usr/bin/pandoc +RTS -K512m -RTS CCC-Weekly-Module-Metrics_RMD.knit.md --to latex --from markdown+autolink_bare_uris+tex_math_single_backslash --output CCC_Weekly_Module_Metrics_05_04_2026_boxfolder_251929835507.tex --lua-filter /usr/local/lib/R/site-library/rmarkdown/rmarkdown/lua/pagebreak.lua --lua-filter /usr/local/lib/R/site-library/rmarkdown/rmarkdown/lua/latex-div.lua --embed-resources --standalone --table-of-contents --toc-depth 2 --highlight-style tango --pdf-engine xelatex --variable graphics --include-in-header /tmp/RtmpSFBrCY/rmarkdown-str17db9923e.html --variable 'geometry:margin=1in' --include-in-header /tmp/RtmpSFBrCY/rmarkdown-str12bda1631.html
2026-05-04 17:06:20.696 EDT [WARNING] Deprecated: --highlight-style. Use --syntax-highlighting instead.
2026-05-04 17:06:37.032 EDT tlmgr: package repository https://latex.us/systems/texlive/tlnet (not verified: gpg unavailable)
2026-05-04 17:06:37.032 EDT [1/1, ??:??/??:??] install: placeins [3k]
```

**Root Cause**
The failure is caused by TinyTeX falling back from a configured repository to the default CTAN mirror network, combined with inconsistent mirror synchronization.

- The configured TinyTeX repository (https://tlnet.yihui.org) became inaccessible or returned invalid responses
- When that occurred, TinyTeX falls back to https://mirror.ctan.org, which dynamically selects a CTAN mirror per request
- CTAN mirrors are not perfectly synchronized and can lag behind each other
As a result:
- Some runs use up-to-date mirrors and succeed
- Other runs use out-of-sync mirrors (e.g., `ctan.math.illinois.edu)` and fail with errors such as:
`Remote database ... seems to be older than the local installation` or
missing LaTeX packages during compilation

This leads to non-deterministic pipeline behavior depending on which mirror is selected at runtime.

**Fix**
Pin TinyTeX to a single, reliable CTAN mirror instead of relying on dynamic mirror selection.

Update install_tinytex() to use a fixed repository:
https://ctan.math.princeton.edu

This ensures:
- Consistent repository usage within each run
- Elimination of cross-mirror inconsistencies
- Reduced likelihood of tlmgr update and package resolution failures

Note: CTAN mirrors are not perfectly synchronized, so the selected mirror may still become temporarily out of sync in the future. However, pinning ensures consistency within a run and significantly reduces intermittent failures.